### PR TITLE
Enable easy xdebug profiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN \
       curl \
       iputils-ping \
       telnet \
+      inotify-tools \
   && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -65,10 +66,19 @@ RUN \
   composer config bin-dir /usr/local/bin && \
   composer install
 
+# Setup xdebug trace and profiler paths.
+RUN \
+  mkdir -p /var/xdebug/internal/profiler/ && \
+  chown -R www-data:www-data /var/xdebug/internal/profiler/ && \
+  mkdir -p /var/xdebug/external/profiler/ && \
+  mkdir -p /var/xdebug/internal/trace/ && \
+  chown -R www-data:www-data /var/xdebug/internal/trace/ && \
+  mkdir -p /var/xdebug/external/trace/
+
 # Put our configurations in place, done as the last step to be able to override
 # default settings from packages.
 COPY files/etc/ /etc/
 
-RUN phpenmod drupal-recommended
+RUN phpenmod drupal-recommended xdebug
 
 EXPOSE 9000

--- a/files/etc/my_init.d/setup-xdebug.sh
+++ b/files/etc/my_init.d/setup-xdebug.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Start watching for profiling files..."
+exec /etc/scripts/xdebug/watch.sh &

--- a/files/etc/php/7.0/mods-available/xdebug.ini
+++ b/files/etc/php/7.0/mods-available/xdebug.ini
@@ -1,0 +1,7 @@
+zend_extension=xdebug.so
+
+xdebug.trace_enable_trigger=1
+xdebug.trace_output_dir=/var/xdebug/internal/trace
+
+xdebug.profiler_enable_trigger=1
+xdebug.profiler_output_dir=/var/xdebug/internal/profiler/

--- a/files/etc/scripts/xdebug/watch.sh
+++ b/files/etc/scripts/xdebug/watch.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+#
+# Script options (exit script on command fail).
+#
+set -e
+
+echo "[Starting inotifywait...]"
+inotifywait -m -r /var/xdebug/internal -e close_write | while read -r path action file;
+do
+    echo "$path $action $file"
+    if [ "$path" = "/var/xdebug/internal/profiler/" ] ; then
+        echo "moved to /var/xdebug/external/profiler/"
+        mv $path$file /var/xdebug/external/profiler/$file
+    else
+        echo "moved to /var/xdebug/external/trace/"
+        mv $path$file /var/xdebug/external/trace/$file
+    fi
+done


### PR DESCRIPTION
Dockerfile - create xdebug profiling and trace directories.
xdebug.ini - setup profiler trigger and trace trigger.
setup-xdebug.sh - start script that start another script in the background.
/scripts/xdebug/watch.sh - background process that copies from the internal profiler directory to the external.

Why the copy: because xdebug is under www-data, and when the xdebug directory is shared with the host, the mount overrides the directory permissions. So as a workaround we listen for new files and copy them using the root user.
