### PR TITLE
Disable xdebug pr default and more

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,13 @@ RUN \
 RUN phpdismod xdebug
 
 # Add the blackfire repo and install the php-probe.
+# We also fetch the blackfire-agent to get access to the commandlineuploader.
 RUN \
   wget -O - https://packagecloud.io/gpg.key | apt-key add - && \
   echo "deb http://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list && \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \
-    apt-get -y install blackfire-php && \
+    apt-get -y install blackfire-php blackfire-agent && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,11 @@ RUN \
       git \
       unzip \
       wget \
+      dnsutils \
       curl \
       iputils-ping \
       telnet \
+      imagemagick \
   && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ RUN \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# We disable xdebug pr default and leave it up to the user of the image to
+# enable at runtime. We disable it right away so that composer used in a
+# later step runs a bit faster.
+RUN phpdismod xdebug
+
 # Add the blackfire repo and install the php-probe.
 RUN \
   wget -O - https://packagecloud.io/gpg.key | apt-key add - && \
@@ -73,6 +78,9 @@ RUN \
 # Put our configurations in place, done as the last step to be able to override
 # default settings from packages.
 COPY files/etc/ /etc/
+
+# Add our tools to PATH.
+COPY files/bin /usr/local/bin/
 
 RUN phpenmod drupal-recommended
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # Generic Drupal-compatible php7 container
 Includes composer and drush, exposes PHP via fpm.
 
+## Xdebug
+Xdebug is disabled pr. default but the extension is available and
+we ship with xdebug.remote_connect_back enabled (when the extension
+is enabled). To enable the xdebug-extension execute
+/usr/local/bin/xdebug-start via docker, eg:
+```
+docker exec -ti <container id> xdebug-start
+```
+
+Or via docker-compose, eg. if the image is used by a service called
+fpm:
+```
+docker-compose exec fpm xdebug-start
+```
+
+The scripts enables xdebug and blocks until the user presses enter
+or terminates the script after which xdebug is disabled again.
+
 ## Blackfire integration
 If the image is run with the environment-variable BLACKFIRE_SOCKET set a blackfire php-probe will be enabled and configured to use the socket. The variable is expected to point to a running blackfire agent.
 Eg. do the following in a docker-compose.yml

--- a/files/bin/xdebug-start
+++ b/files/bin/xdebug-start
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Disable is done on exit, this means that no matter what happens (eg the
+# user doing a ^C) we will attempt to re-disable xdebug.
+disable() {
+    echo '- disabling xdebug' && \
+    phpdismod xdebug
+    echo '- reloading php-fpm'
+    pkill -HUP 'php-fpm'
+    exit $?
+}
+# Trap exit
+trap disable EXIT
+
+# First step is to enable xdebug.
+echo '- enabling xdebug'
+phpenmod xdebug
+echo '- reloading php-fpm'
+pkill -HUP 'php-fpm'
+
+# Then we prompt the user.
+echo ""
+read -p "*** Xdebug enabled, press enter to disable again ***"
+echo ""
+
+# When we reach this point the script exists, and triggers our trap.

--- a/files/etc/php/7.0/fpm/pool.d/www.conf
+++ b/files/etc/php/7.0/fpm/pool.d/www.conf
@@ -359,7 +359,7 @@ pm.max_spare_servers = 3
 ; Note: on highloaded environement, this can cause some delay in the page
 ; process time (several ms).
 ; Default Value: no
-;catch_workers_output = yes
+catch_workers_output = yes
 
 ; Clear environment in FPM workers
 ; Prevents arbitrary environment variables from reaching FPM worker processes


### PR DESCRIPTION
- Added blackfire-agent for sitautions where you want to profile a commandline-tool
- Added imagemagick to support project that avoids GD
- Added a small script to enable xdebug while debugging
- Added dns-tools for debugging of dns-related issues