### PR TITLE
Add bcmath extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN \
       php7.0-xml \
       php7.0-mysql \
       php7.0-mbstring \
+      # BC math is required by Commerce.
+      php7.0-bcmath \
       php-xdebug \
       # Mysql-client added to support eg. drush sqlc
       mysql-client \


### PR DESCRIPTION
Commerce 2.0 requires it. I figure it can't hurt to include it.

Anything I've forgotten?