### PR TITLE
Disable xdebug by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,6 @@ COPY files/bin /usr/local/bin/
 
 RUN phpenmod drupal-recommended
 
-ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mcrypt mysqli mysqlnd opcache pdo pdo_mysql phar posix readline shmop simplexml soap sockets sysvmsg sysvsem sysvshm tokenizer wddx xdebug xml xmlreader xmlwriter xsl mbstring zip
+ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mcrypt mysqli mysqlnd opcache pdo pdo_mysql phar posix readline shmop simplexml soap sockets sysvmsg sysvsem sysvshm tokenizer wddx xml xmlreader xmlwriter xsl mbstring zip
 
 EXPOSE 9000

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ The following PHP extensions will be enabled by default:
  * sysvshm
  * tokenizer
  * wddx
- * xdebug
  * xml
  * xmlreader
  * xmlwriter


### PR DESCRIPTION
phpdismod xdebug runs at first, however later, phpenmod xdebug is executed because xdebug is in the PHP_DEFAULT_EXTENSIONS environment variable.