### PR TITLE
Update Composer to latest version 1.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,13 +62,13 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 1.1.2  using the latest installer.
+# Install composer 1.5.1  using the latest installer.
 # We compare the downloaded installer with a hash from a second source to reduce
 # the chanche we're downloading a compromised installer.
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-  php /tmp/composer-installer --version=1.1.2 --filename=composer --install-dir=/usr/local/bin && \
+  php /tmp/composer-installer --version=1.5.1 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"
 


### PR DESCRIPTION
The latest version has improved support for 
https://github.com/oomphinc/composer-installers-extender, 
https://asset-packagist.org/ and other goodies.