### PR TITLE
Bump phusion base image version for all versions

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.19
+FROM phusion/baseimage:0.10.0
 
 ENV PHP_VERSION 5.6
 

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.19
+FROM phusion/baseimage:0.10.0
 
 ENV PHP_VERSION 7.0
 

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.19
+FROM phusion/baseimage:0.10.0
 
 ENV PHP_VERSION 7.1
 


### PR DESCRIPTION
Verify that the builds kicked off by this PR works for projects using
- [x]  5.6 (verified in HP)
- [x] 7.0
- [ ] 7.1 (ideally, but one of 7.0 and 7.1 would probably be ok)
