### PR TITLE
Add make to images

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -36,6 +36,7 @@ RUN \
       iputils-ping \
       telnet \
       imagemagick \
+      make \
   && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -36,6 +36,7 @@ RUN \
       iputils-ping \
       telnet \
       imagemagick \
+      make \
   && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -36,6 +36,7 @@ RUN \
       iputils-ping \
       telnet \
       imagemagick \
+      make \
   && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -35,6 +35,7 @@ RUN \
       iputils-ping \
       telnet \
       imagemagick \
+      make \
   && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
We are increasingly using Makefiles in our projects. This adds make to
PHP containers which are likely to contain the requirements needed to 
run such scripts.