### PR TITLE
Add wait application to images

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -88,6 +88,13 @@ RUN \
   curl --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 && \
   chmod +x /usr/local/bin/mhsendmail
 
+# Install wait application
+# https://github.com/ufoscout/docker-compose-wait
+ADD \
+  https://github.com/ufoscout/docker-compose-wait/releases/download/2.3.0/wait /wait
+RUN \
+  chmod +x /wait
+
 # Put our configurations in place, done as the last step to be able to override
 # default settings from packages.
 COPY files/etc/ /etc/

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -89,6 +89,13 @@ RUN \
   curl --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 && \
   chmod +x /usr/local/bin/mhsendmail
 
+# Install wait application
+# https://github.com/ufoscout/docker-compose-wait
+ADD \
+  https://github.com/ufoscout/docker-compose-wait/releases/download/2.3.0/wait /wait
+RUN \
+  chmod +x /wait
+
 # Put our configurations in place, done as the last step to be able to override
 # default settings from packages.
 COPY files/etc/ /etc/

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -89,6 +89,13 @@ RUN \
   curl --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 && \
   chmod +x /usr/local/bin/mhsendmail
 
+# Install wait application
+# https://github.com/ufoscout/docker-compose-wait
+ADD \
+  https://github.com/ufoscout/docker-compose-wait/releases/download/2.3.0/wait /wait
+RUN \
+  chmod +x /wait
+
 # Put our configurations in place, done as the last step to be able to override
 # default settings from packages.
 COPY files/etc/ /etc/

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -88,6 +88,13 @@ RUN \
   curl --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 && \
   chmod +x /usr/local/bin/mhsendmail
 
+# Install wait application
+# https://github.com/ufoscout/docker-compose-wait
+ADD \
+  https://github.com/ufoscout/docker-compose-wait/releases/download/2.3.0/wait /wait
+RUN \
+  chmod +x /wait
+
 # Put our configurations in place, done as the last step to be able to override
 # default settings from packages.
 COPY files/etc/ /etc/

--- a/README.md
+++ b/README.md
@@ -175,3 +175,9 @@ services:
 ```
 
 In the above examples the mailhog interface will be accessible on port 8025.
+
+
+## [Wait application](https://github.com/ufoscout/docker-compose-wait)
+
+Allows for waiting on containers, that containers created from these images
+depends upon.


### PR DESCRIPTION
Adds a [wait application](https://github.com/ufoscout/docker-compose-wait) to our images.

This allows processes to wait for ex. a db to be ready before moving on.

This is applicable in reset scripts etc. where some stuff takes longer time and we are afraid of race conditions.