### PR TITLE
Implement tests for contents of Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,45 @@
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test-5.6
+      - test-7.0
+      - test-7.1
+      - test-7.2
+
+shared: &test
+  docker:
+    # Small image which has the key software we need: Docker and Dgoss (or curl needed to instal Dgoss)
+    - image: kiwicom/dgoss
+  steps:
+    - checkout
+    - setup_remote_docker
+    - run:
+        name: Build image
+        command: docker build --file=Dockerfile-${PHP_VERSION} -t docker-drupal-php7-fpm:sut .
+    - run:
+        name: Test
+        command: |
+          # Needed to work with remote docker - see https://github.com/aelsabbahy/goss/pull/271
+          export GOSS_FILES_STRATEGY=cp
+          # Sleep a bit to ensure that PHP-FPM has time to start up.
+          GOSS_SLEEP=15 dgoss run -e GOSS_PHP_VERSION="${PHP_VERSION}" docker-drupal-php7-fpm:sut
+
+version: 2
+jobs:
+  test-5.6:
+    <<: *test
+    environment:
+      PHP_VERSION: "5.6"
+  test-7.0:
+    <<: *test
+    environment:
+      PHP_VERSION: "7.0"
+  test-7.1:
+    <<: *test
+    environment:
+      PHP_VERSION: "7.1"
+  test-7.2:
+    <<: *test
+    environment:
+      PHP_VERSION: "7.2"

--- a/goss.yaml
+++ b/goss.yaml
@@ -1,0 +1,23 @@
+process:
+  # Process names includes the PHP version.
+  php-fpm{{.Env.GOSS_PHP_VERSION}}:
+    running: true
+port:
+{{if eq .Env.GOSS_PHP_VERSION "5.6"}}
+  # GOSS distinguishes between TCP 4 and 6. PHP 5.6 uses 4, PHP 7 uses 6.
+  # Split the tests to reflect this.
+  tcp:9000:
+    listening: true
+    ip:
+    - 0.0.0.0
+{{else}}
+  tcp6:9000:
+    listening: true
+    ip:
+    - '::'
+{{end}}
+command:
+  composer:
+    exit-status: 0
+  drush:
+    exit-status: 0


### PR DESCRIPTION
Use https://github.com/aelsabbahy/goss as a framework for validating
the state of a Linux system. The built in wrapper dgoss makes it easy to
use this for docker images.

The tests check that we have:

- A php-fpm process
- Something which is listening on the expected port (we assume this is
php-fpm)
- Working Composer and Drush commands

Run the test on Circle CI for each of the PHP versions we support.

Thoughts/questions:
- I used Goss by googling testing for Docker images and landed on [a CircleCI blog post]. Other software in this space is [serverspec](https://serverspec.org/) and [Inspec](https://www.inspec.io/). Both seem to be more widely used than Goss. However I think Goss is a nice fit for us:
  1. It has nice integration with Docker which I image is a primary use case for us
  2. The footprint is minimal - no need to install additional software
  3. Tests in YAML are simple to write
- I settled on a [third party docker image](https://github.com/kiwicom/dockerfiles#kiwicomdgoss) to run the tests from. Dgoss needs Docker and curl and I could not find a more established image which had these working.
- If we use such tests to what extent to want to test e.g. Composer/Drush versions, A port which actually responds with something meaningful etc. This is a start which was (relatively) quick to set up.