### PR TITLE
Use cgr for Composer binaries

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -74,14 +74,17 @@ RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"
 
-# Install drush 8 via composer
-# See http://docs.drush.org/en/master/install-alternative/#install-a-global-drush-via-composer
-RUN \
-  mkdir --parents /opt/drush-8.x && \
-  cd /opt/drush-8.x && \
-  composer init --require=drush/drush:8.* -n && \
+# Add cgr as a replacement for composer global require.
+# This ensures that dependencies used by applications installed via composer do not conflict.
+RUN mkdir --parents /opt/composer && \
+  cd /opt/composer && \
+  composer init --require=consolidation/cgr:^2 -n && \
   composer config bin-dir /usr/local/bin && \
   composer install
+ENV CGR_BIN_DIR /usr/local/bin
+
+# Install drush 8 via composer
+RUN cgr drush/drush:8.*
 
 # Install mailhog sender for mailhog integration
 RUN \

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -75,14 +75,17 @@ RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   php -r "unlink('/tmp/composer-installer.sig');" && \
   composer global require "hirak/prestissimo:^0.3"
 
-# Install drush 8 via composer
-# See http://docs.drush.org/en/master/install-alternative/#install-a-global-drush-via-composer
-RUN \
-  mkdir --parents /opt/drush-8.x && \
-  cd /opt/drush-8.x && \
-  composer init --require=drush/drush:8.* -n && \
+# Add cgr as a replacement for composer global require.
+# This ensures that dependencies used by applications installed via composer do not conflict.
+RUN mkdir --parents /opt/composer && \
+  cd /opt/composer && \
+  composer init --require=consolidation/cgr:^2 -n && \
   composer config bin-dir /usr/local/bin && \
   composer install
+ENV CGR_BIN_DIR /usr/local/bin
+
+# Install drush 8 via composer
+RUN cgr drush/drush:8.*
 
 # Install mailhog sender for mailhog integration
 RUN \

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -75,14 +75,17 @@ RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   php -r "unlink('/tmp/composer-installer.sig');" && \
   composer global require "hirak/prestissimo:^0.3"
 
-# Install drush 8 via composer
-# See http://docs.drush.org/en/master/install-alternative/#install-a-global-drush-via-composer
-RUN \
-  mkdir --parents /opt/drush-8.x && \
-  cd /opt/drush-8.x && \
-  composer init --require=drush/drush:8.* -n && \
+# Add cgr as a replacement for composer global require.
+# This ensures that dependencies used by applications installed via composer do not conflict.
+RUN mkdir --parents /opt/composer && \
+  cd /opt/composer && \
+  composer init --require=consolidation/cgr:^2 -n && \
   composer config bin-dir /usr/local/bin && \
   composer install
+ENV CGR_BIN_DIR /usr/local/bin
+
+# Install drush 8 via composer
+RUN cgr drush/drush:8.*
 
 # Install mailhog sender for mailhog integration
 RUN \

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -74,14 +74,17 @@ RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   php -r "unlink('/tmp/composer-installer.sig');" && \
   composer global require "hirak/prestissimo:^0.3"
 
-# Install drush 8 via composer
-# See http://docs.drush.org/en/master/install-alternative/#install-a-global-drush-via-composer
-RUN \
-  mkdir --parents /opt/drush-8.x && \
-  cd /opt/drush-8.x && \
-  composer init --require=drush/drush:8.* -n && \
+# Add cgr as a replacement for composer global require.
+# This ensures that dependencies used by applications installed via composer do not conflict.
+RUN mkdir --parents /opt/composer && \
+  cd /opt/composer && \
+  composer init --require=consolidation/cgr:^2 -n && \
   composer config bin-dir /usr/local/bin && \
   composer install
+ENV CGR_BIN_DIR /usr/local/bin
+
+# Install drush 8 via composer
+RUN cgr drush/drush:8.*
 
 # Install mailhog sender for mailhog integration
 RUN \


### PR DESCRIPTION
We currently use a Drush specific directory for the Drush package. This
makes it tricky to add new packages as well as updating the version of
drush and other existing packages.

Use https://github.com/consolidation/cgr to replace this. It maintains
qualities regarding separation of dependencies per application while
making it easier to maintain tools through a single point of entry:
cgr.

Based on #23.