### PR TITLE
Allow for profiling

### DIFF
--- a/files/etc/php/5.6/mods-available/drupal-recommended.ini
+++ b/files/etc/php/5.6/mods-available/drupal-recommended.ini
@@ -26,6 +26,8 @@ xdebug.remote_enable = 1
 xdebug.remote_connect_back = 1
 ; Drupal recommends that the max nesting level is 256.
 xdebug.max_nesting_level = 256
+; Allow for profiling.
+xdebug.profiler_enable_trigger = 1
 
 ; enable opcache and ensure it has plenty of memory to work  with.
 opcache.enable=1

--- a/files/etc/php/7.0/mods-available/drupal-recommended.ini
+++ b/files/etc/php/7.0/mods-available/drupal-recommended.ini
@@ -26,6 +26,8 @@ xdebug.remote_enable = 1
 xdebug.remote_connect_back = 1
 ; Drupal recommends that the max nesting level is 256.
 xdebug.max_nesting_level = 256
+; Allow for profiling.
+xdebug.profiler_enable_trigger = 1
 
 ; enable opcache and ensure it has plenty of memory to work  with.
 opcache.enable=1

--- a/files/etc/php/7.1/mods-available/drupal-recommended.ini
+++ b/files/etc/php/7.1/mods-available/drupal-recommended.ini
@@ -26,6 +26,8 @@ xdebug.remote_enable = 1
 xdebug.remote_connect_back = 1
 ; Drupal recommends that the max nesting level is 256.
 xdebug.max_nesting_level = 256
+; Allow for profiling.
+xdebug.profiler_enable_trigger = 1
 
 ; enable opcache and ensure it has plenty of memory to work  with.
 opcache.enable=1

--- a/files/etc/php/7.2/mods-available/drupal-recommended.ini
+++ b/files/etc/php/7.2/mods-available/drupal-recommended.ini
@@ -26,6 +26,8 @@ xdebug.remote_enable = 1
 xdebug.remote_connect_back = 1
 ; Drupal recommends that the max nesting level is 256.
 xdebug.max_nesting_level = 256
+; Allow for profiling.
+xdebug.profiler_enable_trigger = 1
 
 ; enable opcache and ensure it has plenty of memory to work  with.
 opcache.enable=1


### PR DESCRIPTION
Allow for triggering xdebug profiling.

Getting the cachegrind file out of /tmp/ in the container is left as an exorcise for the reader.

(one could make a /profiling directory and instruct xdebug to dump them there so one could mount a volume) 