### PR TITLE
Set HEALTHCHECK interval to 5 seconds

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -109,6 +109,6 @@ RUN phpenmod drupal-recommended
 
 ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mcrypt mysqli mysqlnd opcache pdo pdo_mysql phar posix readline shmop simplexml soap sockets sqlite sysvmsg sysvsem sysvshm tokenizer wddx xml xmlreader xmlwriter xsl mbstring zip
 
-HEALTHCHECK CMD ["sh", "-c", "[ -e /tmp/docker-finished-init ]"]
+HEALTHCHECK --interval=5s CMD ["sh", "-c", "[ -e /tmp/docker-finished-init ]"]
 
 EXPOSE 9000

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -110,6 +110,6 @@ RUN phpenmod drupal-recommended
 
 ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mcrypt mysqli mysqlnd opcache pdo pdo_mysql phar posix readline shmop simplexml soap sockets sqlite sysvmsg sysvsem sysvshm tokenizer wddx xml xmlreader xmlwriter xsl mbstring zip
 
-HEALTHCHECK CMD ["sh", "-c", "[ -e /tmp/docker-finished-init ]"]
+HEALTHCHECK --interval=5s CMD ["sh", "-c", "[ -e /tmp/docker-finished-init ]"]
 
 EXPOSE 9000

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -110,6 +110,6 @@ RUN phpenmod drupal-recommended
 
 ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mcrypt mysqli mysqlnd opcache pdo pdo_mysql phar posix readline shmop simplexml soap sockets sqlite sysvmsg sysvsem sysvshm tokenizer wddx xml xmlreader xmlwriter xsl mbstring zip
 
-HEALTHCHECK CMD ["sh", "-c", "[ -e /tmp/docker-finished-init ]"]
+HEALTHCHECK --interval=5s CMD ["sh", "-c", "[ -e /tmp/docker-finished-init ]"]
 
 EXPOSE 9000

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -109,6 +109,6 @@ RUN phpenmod drupal-recommended
 
 ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mysqli mysqlnd opcache pdo pdo_mysql phar posix readline shmop simplexml soap sockets sqlite sysvmsg sysvsem sysvshm tokenizer wddx xml xmlreader xmlwriter xsl mbstring zip
 
-HEALTHCHECK CMD ["sh", "-c", "[ -e /tmp/docker-finished-init ]"]
+HEALTHCHECK --interval=5s CMD ["sh", "-c", "[ -e /tmp/docker-finished-init ]"]
 
 EXPOSE 9000


### PR DESCRIPTION
Docker default health check interval is 30 seconds. We lower that to 5 seconds or else we would have to wait at least 30 seconds on each startup for the container to become healthy.