### PR TITLE
Enable PDO SQLite extension by default

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -107,7 +107,7 @@ COPY files/bin /usr/local/bin/
 
 RUN phpenmod drupal-recommended
 
-ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mcrypt mysqli mysqlnd opcache pdo pdo_mysql phar posix readline shmop simplexml soap sockets sqlite sysvmsg sysvsem sysvshm tokenizer wddx xml xmlreader xmlwriter xsl mbstring zip
+ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mcrypt mysqli mysqlnd opcache pdo pdo_mysql pdo_sqlite phar posix readline shmop simplexml soap sockets sqlite sysvmsg sysvsem sysvshm tokenizer wddx xml xmlreader xmlwriter xsl mbstring zip
 
 HEALTHCHECK --interval=5s CMD ["sh", "-c", "[ -e /tmp/docker-finished-init ]"]
 

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -108,7 +108,7 @@ COPY files/bin /usr/local/bin/
 
 RUN phpenmod drupal-recommended
 
-ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mcrypt mysqli mysqlnd opcache pdo pdo_mysql phar posix readline shmop simplexml soap sockets sqlite sysvmsg sysvsem sysvshm tokenizer wddx xml xmlreader xmlwriter xsl mbstring zip
+ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mcrypt mysqli mysqlnd opcache pdo pdo_mysql pdo_sqlite phar posix readline shmop simplexml soap sockets sqlite sysvmsg sysvsem sysvshm tokenizer wddx xml xmlreader xmlwriter xsl mbstring zip
 
 HEALTHCHECK --interval=5s CMD ["sh", "-c", "[ -e /tmp/docker-finished-init ]"]
 

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -108,7 +108,7 @@ COPY files/bin /usr/local/bin/
 
 RUN phpenmod drupal-recommended
 
-ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mcrypt mysqli mysqlnd opcache pdo pdo_mysql phar posix readline shmop simplexml soap sockets sqlite sysvmsg sysvsem sysvshm tokenizer wddx xml xmlreader xmlwriter xsl mbstring zip
+ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mcrypt mysqli mysqlnd opcache pdo pdo_mysql pdo_sqlite phar posix readline shmop simplexml soap sockets sqlite sysvmsg sysvsem sysvshm tokenizer wddx xml xmlreader xmlwriter xsl mbstring zip
 
 HEALTHCHECK --interval=5s CMD ["sh", "-c", "[ -e /tmp/docker-finished-init ]"]
 

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -107,7 +107,7 @@ COPY files/bin /usr/local/bin/
 
 RUN phpenmod drupal-recommended
 
-ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mysqli mysqlnd opcache pdo pdo_mysql phar posix readline shmop simplexml soap sockets sqlite sysvmsg sysvsem sysvshm tokenizer wddx xml xmlreader xmlwriter xsl mbstring zip
+ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mysqli mysqlnd opcache pdo pdo_mysql pdo_sqlite phar posix readline shmop simplexml soap sockets sqlite sysvmsg sysvsem sysvshm tokenizer wddx xml xmlreader xmlwriter xsl mbstring zip
 
 HEALTHCHECK --interval=5s CMD ["sh", "-c", "[ -e /tmp/docker-finished-init ]"]
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The following PHP extensions will be enabled by default:
  * opcache
  * pdo
  * pdo_mysql
+ * pdo_sqlite
  * phar
  * posix
  * readline


### PR DESCRIPTION
We have the SQLite extension added already. There is no reason not to
have the PDO extension also.

The PDO extension is required when using a SQLite connection - e.g.
when running kernel tests.