### PR TITLE
Add request URI to XDebug profiler output filenames

### DIFF
--- a/files/etc/php/5.6/mods-available/drupal-recommended.ini
+++ b/files/etc/php/5.6/mods-available/drupal-recommended.ini
@@ -28,6 +28,8 @@ xdebug.remote_connect_back = 1
 xdebug.max_nesting_level = 256
 ; Allow for profiling.
 xdebug.profiler_enable_trigger = 1
+; Include request URI in profiler filenames.
+xdebug.profiler_output_name = cachegrind.out.%R.%p
 
 ; enable opcache and ensure it has plenty of memory to work  with.
 opcache.enable=1

--- a/files/etc/php/7.0/mods-available/drupal-recommended.ini
+++ b/files/etc/php/7.0/mods-available/drupal-recommended.ini
@@ -28,6 +28,8 @@ xdebug.remote_connect_back = 1
 xdebug.max_nesting_level = 256
 ; Allow for profiling.
 xdebug.profiler_enable_trigger = 1
+; Include request URI in profiler filenames.
+xdebug.profiler_output_name = cachegrind.out.%R.%p
 
 ; enable opcache and ensure it has plenty of memory to work  with.
 opcache.enable=1

--- a/files/etc/php/7.1/mods-available/drupal-recommended.ini
+++ b/files/etc/php/7.1/mods-available/drupal-recommended.ini
@@ -28,6 +28,8 @@ xdebug.remote_connect_back = 1
 xdebug.max_nesting_level = 256
 ; Allow for profiling.
 xdebug.profiler_enable_trigger = 1
+; Include request URI in profiler filenames.
+xdebug.profiler_output_name = cachegrind.out.%R.%p
 
 ; enable opcache and ensure it has plenty of memory to work  with.
 opcache.enable=1

--- a/files/etc/php/7.2/mods-available/drupal-recommended.ini
+++ b/files/etc/php/7.2/mods-available/drupal-recommended.ini
@@ -28,6 +28,8 @@ xdebug.remote_connect_back = 1
 xdebug.max_nesting_level = 256
 ; Allow for profiling.
 xdebug.profiler_enable_trigger = 1
+; Include request URI in profiler filenames.
+xdebug.profiler_output_name = cachegrind.out.%R.%p
 
 ; enable opcache and ensure it has plenty of memory to work  with.
 opcache.enable=1


### PR DESCRIPTION
By default these filenames only include the process id. This combined 
with the fact that Drupal uses a front controller where all requests
pass through index.php makes it hard to identify which profiler file
was generated by what request when using tools like Webgrind.

With this change the request URI is included in the profiler filename so
what would previously result in a filename such as
cachegrind.out.5224 now becomes
cachegrind.out._search_ting_danmark_.5224