### PR TITLE
Add gosu to the image

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -33,6 +33,7 @@ RUN \
       iputils-ping \
       telnet \
       imagemagick \
+      gosu \
       patch
 
 # We disable xdebug pr default and leave it up to the user of the image to

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -33,6 +33,7 @@ RUN \
       iputils-ping \
       telnet \
       imagemagick \
+      gosu \
       patch
 
 # We disable xdebug pr default and leave it up to the user of the image to

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -33,6 +33,7 @@ RUN \
       iputils-ping \
       telnet \
       imagemagick \
+      gosu \
       patch
 
 # We disable xdebug pr default and leave it up to the user of the image to

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -32,6 +32,7 @@ RUN \
       iputils-ping \
       telnet \
       imagemagick \
+      gosu \
       patch
 
 # We disable xdebug pr default and leave it up to the user of the image to


### PR DESCRIPTION
Having gosu lets us have a standardized way of handling processes without using
sudo.

See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user