### PR TITLE
Add Github Actions

### DIFF
--- a/.github/actions/buildtest-action/Dockerfile
+++ b/.github/actions/buildtest-action/Dockerfile
@@ -1,0 +1,7 @@
+FROM docker:stable
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENV VERSION=5.6
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/buildtest-action/entrypoint.sh
+++ b/.github/actions/buildtest-action/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -l
+
+set -euxo pipefail
+
+# Build image.
+docker build --file=Dockerfile-${VERSION} -t docker-drupal-php7-fpm:sut-${VERSION} .
+
+# Build another baseed on the first with test tool.
+docker build --build-arg VERSION=${VERSION} --file=Dockerfile-goss -t docker-drupal-php7-fpm:sut-${VERSION} .
+
+# Run test. Set home for composer (else it gets angry) and use wait-for-it to wait for FPM startup.
+docker run -e GOSS_PHP_VERSION=${VERSION} docker-drupal-php7-fpm:sut-${VERSION} /sbin/my_init -- sh -c "export HOME=/root && wait-for-it -t 5 localhost:9000 && /goss/goss -g /goss/goss.yaml validate --format documentation" 

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,39 @@
+workflow "Build and test" {
+  on = "push"
+  resolves = ["Test-5.6", "Test-7.0", "Test-7.1", "Test-7.2", "Test-7.3"]
+}
+
+action "Test-5.6" {
+  uses = "./.github/actions/buildtest-action"
+  env = {
+    VERSION = "5.6"
+  }
+}
+
+action "Test-7.0" {
+  uses = "./.github/actions/buildtest-action"
+  env = {
+    VERSION = "7.0"
+  }
+}
+
+action "Test-7.1" {
+  uses = "./.github/actions/buildtest-action"
+  env = {
+    VERSION = "7.1"
+  }
+}
+
+action "Test-7.2" {
+  uses = "./.github/actions/buildtest-action"
+  env = {
+    VERSION = "7.2"
+  }
+}
+
+action "Test-7.3" {
+  uses = "./.github/actions/buildtest-action"
+  env = {
+    VERSION = "7.3"
+  }
+}

--- a/Dockerfile-goss
+++ b/Dockerfile-goss
@@ -1,0 +1,8 @@
+ARG VERSION
+FROM docker-drupal-php7-fpm:sut-${VERSION}
+
+RUN mkdir /goss && \
+        curl -L https://github.com/aelsabbahy/goss/releases/download/v0.3.6/goss-linux-amd64 -o /goss/goss && \
+        chmod +rx /goss/goss
+
+COPY goss.yaml /goss


### PR DESCRIPTION
Github actions doesn't allow some docker operations for security reasons, such as `exec`ing into a container, so this uses another approach:

For starters we define an action for the build and test process. This allows us to run the action with a single `VERSION` parameter.

Then we build the image as before.

Then we build another image based on the just built image which installs goss and its config file.

For the actual test we then run the last build image with arguments to make my_init start up as usual and run goss. As a bonus we use `wait-for-it instead` of `sleep 15` to speed up the process.