### PR TITLE
Scan Dockerfiles with Anchore

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,22 +2,23 @@ on: pull_request
 name: Run Goss tests
 
 jobs:
+  php-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.php-versions.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v2.3.3
+    - name: Lookup PHP versions from Dockerfile-* names
+      run: echo ::set-output name=matrix::$(ls Dockerfile-* | cut -c 12- | jq --raw-input --slurp 'split("\n") | map(select(. != ""))')
+      id: php-versions
   goss_test:
     name: Goss test
     runs-on: ubuntu-latest
+    needs: php-versions
     strategy:
       fail-fast: false
       matrix:
-        php:
-          # Strings, so they wont be parsed as floats which would
-          # transform "7.0" into "7".
-          - "5.6"
-          - "7.0"
-          - "7.1"
-          - "7.2"
-          - "7.3"
-          - "7.4"
-          - "8.0"
+        php: ${{ fromJSON(needs.php-versions.outputs.matrix) }}
     steps:
     - uses: actions/checkout@v2
     - name: Run hadolint

--- a/.github/workflows/scan-dockerfile.yml
+++ b/.github/workflows/scan-dockerfile.yml
@@ -1,0 +1,37 @@
+name: Anchore Container Vulnerability Scan
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+    steps:
+    - uses: actions/checkout@v2.3.3
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@master
+    - name: Build Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: Dockerfile-${{ matrix.php }}
+        builder: ${{ steps.buildx.outputs.name }}
+        tags: "reload/drupal-php7-fpm:${{ matrix.php }}"
+        push: false
+    - name: Anchore Container Vulnerability Scan
+      uses: anchore/scan-action@v2
+      id: scan
+      with:
+        image: "reload/drupal-php7-fpm:${{ matrix.php }}"
+        acs-report-enable: true
+    - name: Include PHP version in SARIF report
+      if: ${{ always() }}
+      run: |
+        sed -i.bak -e 's|"fullyQualifiedName": "dockerfile"|"fullyQualifiedName": "Dockerfile-${{ matrix.php }}"|g' ${{ steps.scan.outputs.sarif }}
+        sed -i.bak -e 's|"name": "Anchore Container Vulnerability Report (T0)"|"name": "Anchore (Dockerfile-${{ matrix.php }})"|g' ${{ steps.scan.outputs.sarif }}
+    - name: Upload Anchore Container Vulnerability Scan SARIF report
+      if: ${{ always() }}
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: ${{ steps.scan.outputs.sarif }}

--- a/.github/workflows/scan-dockerfile.yml
+++ b/.github/workflows/scan-dockerfile.yml
@@ -1,11 +1,21 @@
 name: Anchore Container Vulnerability Scan
 on: [push]
 jobs:
+  php-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.php-versions.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v2.3.3
+    - name: Lookup PHP versions from Dockerfile-* names
+      run: echo ::set-output name=matrix::$(ls Dockerfile-* | cut -c 12- | jq --raw-input --slurp 'split("\n") | map(select(. != ""))')
+      id: php-versions
   build:
     runs-on: ubuntu-latest
+    needs: php-versions
     strategy:
       matrix:
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ${{ fromJSON(needs.php-versions.outputs.matrix) }}
     steps:
     - uses: actions/checkout@v2.3.3
     - name: Set up Docker Buildx


### PR DESCRIPTION
Et gammel PR jeg havde liggende med at teste security scan af dockerfiles.

Det har egentlig fået lov at ligge fordi det [finder mange sårbarheder](https://github.com/reload/docker-drupal-php7-fpm/security/code-scanning?query=ref%3Arefs%2Fheads%2Fscan-dockerfile+tool%3A%22Anchore+%28Dockerfile-7.4%29%22+is%3Aopen+) fordi de her dockerfiles er baseret på Ubuntu, men på den anden side bliver der jo ikke færre sårbarheder af at vi ikke scanner dem. Så jeg tænker vi godt kan merge det.

Og så har jeg smidt et commit med så man ikke skal holde GitHub Action workflow-filer i sync med hvilke PHP versioner vi docker filer til, men at vi hiver dem ud dynamisk.