### PR TITLE
Update composer to 2.0.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ workflows:
       - test-7.1
       - test-7.2
       - test-7.3
+      - test-7.4
 
 shared: &test
   docker:

--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -55,14 +55,14 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 2.0.2  using the latest installer.
+# Install composer 2.0.3  using the latest installer.
 # We compare the downloaded installer with a hash from a second source to reduce
 # the chanche we're downloading a compromised installer.
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
   php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
-  php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
+  php /tmp/composer-installer --version=2.0.3 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"
 

--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -55,16 +55,9 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 2.0.3  using the latest installer.
-# We compare the downloaded installer with a hash from a second source to reduce
-# the chanche we're downloading a compromised installer.
-RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
-  curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
-  php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-  php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
-  php /tmp/composer-installer --version=2.0.3 --filename=composer --install-dir=/usr/local/bin && \
-  php -r "unlink('/tmp/composer-installer');" && \
-  php -r "unlink('/tmp/composer-installer.sig');"
+# Copy Composer in from official images
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1 /usr/bin/composer /usr/bin/composer-1
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -55,13 +55,13 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 1.6.5  using the latest installer.
+# Install composer 2.0.2  using the latest installer.
 # We compare the downloaded installer with a hash from a second source to reduce
 # the chanche we're downloading a compromised installer.
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-  php /tmp/composer-installer --version=1.6.5 --filename=composer --install-dir=/usr/local/bin && \
+  php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"
 

--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -61,6 +61,7 @@ RUN \
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
+  php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
   php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -55,14 +55,14 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 2.0.2  using the latest installer.
+# Install composer 2.0.3  using the latest installer.
 # We compare the downloaded installer with a hash from a second source to reduce
 # the chanche we're downloading a compromised installer.
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
   php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
-  php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
+  php /tmp/composer-installer --version=2.0.3 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"
 

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -55,16 +55,9 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 2.0.3  using the latest installer.
-# We compare the downloaded installer with a hash from a second source to reduce
-# the chanche we're downloading a compromised installer.
-RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
-  curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
-  php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-  php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
-  php /tmp/composer-installer --version=2.0.3 --filename=composer --install-dir=/usr/local/bin && \
-  php -r "unlink('/tmp/composer-installer');" && \
-  php -r "unlink('/tmp/composer-installer.sig');"
+# Copy Composer in from official images
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1 /usr/bin/composer /usr/bin/composer-1
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -55,16 +55,15 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 1.6.5  using the latest installer.
+# Install composer 2.0.2  using the latest installer.
 # We compare the downloaded installer with a hash from a second source to reduce
 # the chanche we're downloading a compromised installer.
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-  php /tmp/composer-installer --version=1.6.5 --filename=composer --install-dir=/usr/local/bin && \
+  php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
-  php -r "unlink('/tmp/composer-installer.sig');" && \
-  composer global require "hirak/prestissimo:^0.3"
+  php -r "unlink('/tmp/composer-installer.sig');"
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -61,6 +61,7 @@ RUN \
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
+  php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
   php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -55,14 +55,14 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 2.0.2  using the latest installer.
+# Install composer 2.0.3  using the latest installer.
 # We compare the downloaded installer with a hash from a second source to reduce
 # the chanche we're downloading a compromised installer.
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
   php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
-  php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
+  php /tmp/composer-installer --version=2.0.3 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"
 

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -55,16 +55,9 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 2.0.3  using the latest installer.
-# We compare the downloaded installer with a hash from a second source to reduce
-# the chanche we're downloading a compromised installer.
-RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
-  curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
-  php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-  php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
-  php /tmp/composer-installer --version=2.0.3 --filename=composer --install-dir=/usr/local/bin && \
-  php -r "unlink('/tmp/composer-installer');" && \
-  php -r "unlink('/tmp/composer-installer.sig');"
+# Copy Composer in from official images
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1 /usr/bin/composer /usr/bin/composer-1
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -55,16 +55,15 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 1.6.5  using the latest installer.
+# Install composer 2.0.2  using the latest installer.
 # We compare the downloaded installer with a hash from a second source to reduce
 # the chanche we're downloading a compromised installer.
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-  php /tmp/composer-installer --version=1.6.5 --filename=composer --install-dir=/usr/local/bin && \
+  php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
-  php -r "unlink('/tmp/composer-installer.sig');" && \
-  composer global require "hirak/prestissimo:^0.3"
+  php -r "unlink('/tmp/composer-installer.sig');"
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -61,6 +61,7 @@ RUN \
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
+  php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
   php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -54,16 +54,9 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 2.0.3  using the latest installer.
-# We compare the downloaded installer with a hash from a second source to reduce
-# the chanche we're downloading a compromised installer.
-RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
-  curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
-  php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-  php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
-  php /tmp/composer-installer --version=2.0.3 --filename=composer --install-dir=/usr/local/bin && \
-  php -r "unlink('/tmp/composer-installer');" && \
-  php -r "unlink('/tmp/composer-installer.sig');"
+# Copy Composer in from official images
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1 /usr/bin/composer /usr/bin/composer-1
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -54,16 +54,15 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 1.6.5  using the latest installer.
+# Install composer 2.0.2  using the latest installer.
 # We compare the downloaded installer with a hash from a second source to reduce
 # the chanche we're downloading a compromised installer.
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-  php /tmp/composer-installer --version=1.6.5 --filename=composer --install-dir=/usr/local/bin && \
+  php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
-  php -r "unlink('/tmp/composer-installer.sig');" && \
-  composer global require "hirak/prestissimo:^0.3"
+  php -r "unlink('/tmp/composer-installer.sig');"
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -54,14 +54,14 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 2.0.2  using the latest installer.
+# Install composer 2.0.3  using the latest installer.
 # We compare the downloaded installer with a hash from a second source to reduce
 # the chanche we're downloading a compromised installer.
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
   php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
-  php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
+  php /tmp/composer-installer --version=2.0.3 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"
 

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -60,6 +60,7 @@ RUN \
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
+  php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
   php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -54,16 +54,9 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 2.0.3  using the latest installer.
-# We compare the downloaded installer with a hash from a second source to reduce
-# the chanche we're downloading a compromised installer.
-RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
-  curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
-  php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-  php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
-  php /tmp/composer-installer --version=2.0.3 --filename=composer --install-dir=/usr/local/bin && \
-  php -r "unlink('/tmp/composer-installer');" && \
-  php -r "unlink('/tmp/composer-installer.sig');"
+# Copy Composer in from official images
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1 /usr/bin/composer /usr/bin/composer-1
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -54,16 +54,15 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 1.6.5  using the latest installer.
+# Install composer 2.0.2  using the latest installer.
 # We compare the downloaded installer with a hash from a second source to reduce
 # the chanche we're downloading a compromised installer.
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-  php /tmp/composer-installer --version=1.6.5 --filename=composer --install-dir=/usr/local/bin && \
+  php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
-  php -r "unlink('/tmp/composer-installer.sig');" && \
-  composer global require "hirak/prestissimo:^0.3"
+  php -r "unlink('/tmp/composer-installer.sig');"
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -54,14 +54,14 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 2.0.2  using the latest installer.
+# Install composer 2.0.3  using the latest installer.
 # We compare the downloaded installer with a hash from a second source to reduce
 # the chanche we're downloading a compromised installer.
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
   php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
-  php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
+  php /tmp/composer-installer --version=2.0.3 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"
 

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -60,6 +60,7 @@ RUN \
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
+  php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
   php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -54,16 +54,9 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 2.0.3  using the latest installer.
-# We compare the downloaded installer with a hash from a second source to reduce
-# the chanche we're downloading a compromised installer.
-RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
-  curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
-  php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-  php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
-  php /tmp/composer-installer --version=2.0.3 --filename=composer --install-dir=/usr/local/bin && \
-  php -r "unlink('/tmp/composer-installer');" && \
-  php -r "unlink('/tmp/composer-installer.sig');"
+# Copy Composer in from official images
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1 /usr/bin/composer /usr/bin/composer-1
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -54,16 +54,15 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 1.6.5  using the latest installer.
+# Install composer 2.0.2  using the latest installer.
 # We compare the downloaded installer with a hash from a second source to reduce
 # the chanche we're downloading a compromised installer.
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-  php /tmp/composer-installer --version=1.6.5 --filename=composer --install-dir=/usr/local/bin && \
+  php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
-  php -r "unlink('/tmp/composer-installer.sig');" && \
-  composer global require "hirak/prestissimo:^0.3"
+  php -r "unlink('/tmp/composer-installer.sig');"
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -54,14 +54,14 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Install composer 2.0.2  using the latest installer.
+# Install composer 2.0.3  using the latest installer.
 # We compare the downloaded installer with a hash from a second source to reduce
 # the chanche we're downloading a compromised installer.
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
   php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
-  php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
+  php /tmp/composer-installer --version=2.0.3 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"
 

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -60,6 +60,7 @@ RUN \
 RUN curl -o /tmp/composer-installer https://getcomposer.org/installer && \
   curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
   php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
+  php /tmp/composer-installer --version=1.10.16 --filename=composer-1 --install-dir=/usr/local/bin && \
   php /tmp/composer-installer --version=2.0.2 --filename=composer --install-dir=/usr/local/bin && \
   php -r "unlink('/tmp/composer-installer');" && \
   php -r "unlink('/tmp/composer-installer.sig');"

--- a/goss.yaml
+++ b/goss.yaml
@@ -19,6 +19,8 @@ port:
 command:
   composer:
     exit-status: 0
+  composer-1:
+    exit-status: 0
   drush:
     exit-status: 0
   # Test wait-for-it by testing a port we know is available at this point.


### PR DESCRIPTION
Update the pretty ancient composer 1.6.5 to 2.0.2.

Add a `composer-1` for those not quite ready. 

Removes `hirak/prestissimo` as it's not compatible with Composer 2, and Composer 2 is much faster anyway. Just another incentive for those using Composer 1 to upgrade.

Add missing test of 7.4
