### PR TITLE
Install specific versions of extensions

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -13,16 +13,16 @@ RUN \
       php${PHP_VERSION}-xml \
       php${PHP_VERSION}-mysql \
       php${PHP_VERSION}-mbstring \
-      php-xdebug \
+      php${PHP_VERSION}-xdebug \
       php${PHP_VERSION}-mcrypt \
       php${PHP_VERSION}-soap \
       php${PHP_VERSION}-sqlite3 \
       php${PHP_VERSION}-zip \
       php${PHP_VERSION}-intl \
       php${PHP_VERSION}-bcmath \
-      php-imagick \
-      php-memcache \
-      php-memcached \
+      php${PHP_VERSION}-imagick \
+      php${PHP_VERSION}-memcache \
+      php${PHP_VERSION}-memcached \
       # Mysql-client added to support eg. drush sqlc
       mysql-client \
       # Git and unzip are required by composer

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -13,16 +13,16 @@ RUN \
       php${PHP_VERSION}-xml \
       php${PHP_VERSION}-mysql \
       php${PHP_VERSION}-mbstring \
-      php-xdebug \
+      php${PHP_VERSION}-xdebug \
       php${PHP_VERSION}-mcrypt \
       php${PHP_VERSION}-soap \
       php${PHP_VERSION}-sqlite3 \
       php${PHP_VERSION}-zip \
       php${PHP_VERSION}-intl \
       php${PHP_VERSION}-bcmath \
-      php-imagick \
-      php-memcache \
-      php-memcached \
+      php${PHP_VERSION}-imagick \
+      php${PHP_VERSION}-memcache \
+      php${PHP_VERSION}-memcached \
       # Mysql-client added to support eg. drush sqlc
       mysql-client \
       # Git and unzip are required by composer

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -13,16 +13,16 @@ RUN \
       php${PHP_VERSION}-xml \
       php${PHP_VERSION}-mysql \
       php${PHP_VERSION}-mbstring \
-      php-xdebug \
+      php${PHP_VERSION}-xdebug \
       php${PHP_VERSION}-mcrypt \
       php${PHP_VERSION}-soap \
       php${PHP_VERSION}-sqlite3 \
       php${PHP_VERSION}-zip \
       php${PHP_VERSION}-intl \
       php${PHP_VERSION}-bcmath \
-      php-imagick \
-      php-memcache \
-      php-memcached \
+      php${PHP_VERSION}-imagick \
+      php${PHP_VERSION}-memcache \
+      php${PHP_VERSION}-memcached \
       # Mysql-client added to support eg. drush sqlc
       mysql-client \
       # Git and unzip are required by composer

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -13,15 +13,15 @@ RUN \
       php${PHP_VERSION}-xml \
       php${PHP_VERSION}-mysql \
       php${PHP_VERSION}-mbstring \
-      php-xdebug \
+      php${PHP_VERSION}-xdebug \
       php${PHP_VERSION}-soap \
       php${PHP_VERSION}-sqlite3 \
       php${PHP_VERSION}-zip \
       php${PHP_VERSION}-intl \
       php${PHP_VERSION}-bcmath \
-      php-imagick \
-      php-memcache \
-      php-memcached \
+      php${PHP_VERSION}-imagick \
+      php${PHP_VERSION}-memcache \
+      php${PHP_VERSION}-memcached \
       # Mysql-client added to support eg. drush sqlc
       mysql-client \
       # Git and unzip are required by composer

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -13,15 +13,15 @@ RUN \
       php${PHP_VERSION}-xml \
       php${PHP_VERSION}-mysql \
       php${PHP_VERSION}-mbstring \
-      php-xdebug \
+      php${PHP_VERSION}-xdebug \
       php${PHP_VERSION}-soap \
       php${PHP_VERSION}-sqlite3 \
       php${PHP_VERSION}-zip \
       php${PHP_VERSION}-intl \
       php${PHP_VERSION}-bcmath \
-      php-imagick \
-      php-memcache \
-      php-memcached \
+      php${PHP_VERSION}-imagick \
+      php${PHP_VERSION}-memcache \
+      php${PHP_VERSION}-memcached \
       # Mysql-client added to support eg. drush sqlc
       mysql-client \
       # Git and unzip are required by composer

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -13,15 +13,15 @@ RUN \
       php${PHP_VERSION}-xml \
       php${PHP_VERSION}-mysql \
       php${PHP_VERSION}-mbstring \
-      php-xdebug \
+      php${PHP_VERSION}-xdebug \
       php${PHP_VERSION}-soap \
       php${PHP_VERSION}-sqlite3 \
       php${PHP_VERSION}-zip \
       php${PHP_VERSION}-intl \
       php${PHP_VERSION}-bcmath \
-      php-imagick \
-      php-memcache \
-      php-memcached \
+      php${PHP_VERSION}-imagick \
+      php${PHP_VERSION}-memcache \
+      php${PHP_VERSION}-memcached \
       # Mysql-client added to support eg. drush sqlc
       mysql-client \
       # Git and unzip are required by composer


### PR DESCRIPTION
See https://www.patreon.com/posts/october-update-42636315:

> The news that good and bad at the same time - the build system for PECL extensions underwent a major overhaul that require a manual intervention. The extensions for individual PHP releases have been split into individual versioned packages and the main (unversioned) package now depends on all versioned packages. This is the "do least harm" version because the worst case here is that phpX.Y-cli for every supported PHP release will get installed, but you won't lose any functionality in any previously installed PHP release. Here's the example: previously, php-apcu previously contained extensions for all supported PHP releases, so when you installed it, apcu.so binary modules would be installed for PHP 5.6, and PHP 7.0-PHP 7.4. With the new layout, php-apcu is a dummy dependency package that depends on php5.6-apcu, php7.0-apcu, and so on for all supported PHP releases. You need to pick specific versions of the PECL extension packages, so instead of installing php-apcu you need to install f.e. php7.4-apcu. Unfortunately, there's no way how to accomplish this automatically, as apt doesn't have facility to specify conditional dependencies, so it will require manual intervention from the operator.
