### PR TITLE
Install updates (mostly for security updates)

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -3,6 +3,12 @@ FROM phusion/baseimage:0.11
 
 ENV PHP_VERSION 5.6
 
+# Install updates (mostly for security updates)
+RUN apt-get -q update && apt-get -qy upgrade \
+    && apt-get -qy autoremove \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists/*
+
 # Basic package installation
 RUN \
   # Add a repo that contains php ${PHP_VERSION}

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -3,6 +3,12 @@ FROM phusion/baseimage:0.11
 
 ENV PHP_VERSION 7.0
 
+# Install updates (mostly for security updates)
+RUN apt-get -q update && apt-get -qy upgrade \
+    && apt-get -qy autoremove \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists/*
+
 # Basic package installation
 RUN \
   # Add a repo that contains php ${PHP_VERSION}

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -3,6 +3,12 @@ FROM phusion/baseimage:0.11
 
 ENV PHP_VERSION 7.1
 
+# Install updates (mostly for security updates)
+RUN apt-get -q update && apt-get -qy upgrade \
+    && apt-get -qy autoremove \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists/*
+
 # Basic package installation
 RUN \
   # Add a repo that contains php ${PHP_VERSION}

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -3,6 +3,12 @@ FROM phusion/baseimage:0.11
 
 ENV PHP_VERSION 7.2
 
+# Install updates (mostly for security updates)
+RUN apt-get -q update && apt-get -qy upgrade \
+    && apt-get -qy autoremove \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists/*
+
 # Basic package installation
 RUN \
   # Add a repo that contains php ${PHP_VERSION}

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -3,6 +3,12 @@ FROM phusion/baseimage:0.11
 
 ENV PHP_VERSION 7.3
 
+# Install updates (mostly for security updates)
+RUN apt-get -q update && apt-get -qy upgrade \
+    && apt-get -qy autoremove \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists/*
+
 # Basic package installation
 RUN \
   # Add a repo that contains php ${PHP_VERSION}

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -3,6 +3,12 @@ FROM phusion/baseimage:0.11
 
 ENV PHP_VERSION 7.4
 
+# Install updates (mostly for security updates)
+RUN apt-get -q update && apt-get -qy upgrade \
+    && apt-get -qy autoremove \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists/*
+
 # Basic package installation
 RUN \
   # Add a repo that contains php ${PHP_VERSION}

--- a/Dockerfile-8.0
+++ b/Dockerfile-8.0
@@ -3,6 +3,12 @@ FROM phusion/baseimage:0.11
 
 ENV PHP_VERSION 8.0
 
+# Install updates (mostly for security updates)
+RUN apt-get -q update && apt-get -qy upgrade \
+    && apt-get -qy autoremove \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists/*
+
 # Basic package installation
 RUN \
   # Add a repo that contains php ${PHP_VERSION}


### PR DESCRIPTION
The base image might not be totally up to date. This doesn't ensure our images are always updated but at least they will be up to date at build time (which is better than today).