### PR TITLE
Bump phusion/baseimage from 0.11 to focal-1.0.0

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -2,7 +2,7 @@
 FROM composer:1 AS composer-1
 FROM composer:2 AS composer-2
 
-FROM phusion/baseimage:0.11
+FROM phusion/baseimage:focal-1.0.0
 
 ENV PHP_VERSION 5.6
 

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -2,7 +2,7 @@
 FROM composer:1 AS composer-1
 FROM composer:2 AS composer-2
 
-FROM phusion/baseimage:0.11
+FROM phusion/baseimage:focal-1.0.0
 
 ENV PHP_VERSION 7.0
 

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -2,7 +2,7 @@
 FROM composer:1 AS composer-1
 FROM composer:2 AS composer-2
 
-FROM phusion/baseimage:0.11
+FROM phusion/baseimage:focal-1.0.0
 
 ENV PHP_VERSION 7.1
 

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -2,7 +2,7 @@
 FROM composer:1 AS composer-1
 FROM composer:2 AS composer-2
 
-FROM phusion/baseimage:0.11
+FROM phusion/baseimage:focal-1.0.0
 
 ENV PHP_VERSION 7.2
 

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -2,7 +2,7 @@
 FROM composer:1 AS composer-1
 FROM composer:2 AS composer-2
 
-FROM phusion/baseimage:0.11
+FROM phusion/baseimage:focal-1.0.0
 
 ENV PHP_VERSION 7.3
 

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -2,7 +2,7 @@
 FROM composer:1 AS composer-1
 FROM composer:2 AS composer-2
 
-FROM phusion/baseimage:0.11
+FROM phusion/baseimage:focal-1.0.0
 
 ENV PHP_VERSION 7.4
 

--- a/Dockerfile-8.0
+++ b/Dockerfile-8.0
@@ -2,7 +2,7 @@
 FROM composer:1 AS composer-1
 FROM composer:2 AS composer-2
 
-FROM phusion/baseimage:0.11
+FROM phusion/baseimage:focal-1.0.0
 
 ENV PHP_VERSION 8.0
 


### PR DESCRIPTION
This is the latest tagged release. It is based on Ubuntu 20.04 
(Focal Fossa).