### PR TITLE
Use mariadb-client instead of mysql-client

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -36,8 +36,8 @@ RUN \
       php${PHP_VERSION}-imagick \
       php${PHP_VERSION}-memcache \
       php${PHP_VERSION}-memcached \
-      # Mysql-client added to support eg. drush sqlc
-      mysql-client \
+      # mariadb-client added to support eg. drush sqlc
+      mariadb-client \
       # Git and unzip are required by composer
       git \
       unzip \

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -36,8 +36,8 @@ RUN \
       php${PHP_VERSION}-imagick \
       php${PHP_VERSION}-memcache \
       php${PHP_VERSION}-memcached \
-      # Mysql-client added to support eg. drush sqlc
-      mysql-client \
+      # mariadb-client added to support eg. drush sqlc
+      mariadb-client \
       # Git and unzip are required by composer
       git \
       unzip \

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -36,8 +36,8 @@ RUN \
       php${PHP_VERSION}-imagick \
       php${PHP_VERSION}-memcache \
       php${PHP_VERSION}-memcached \
-      # Mysql-client added to support eg. drush sqlc
-      mysql-client \
+      # mariadb-client added to support eg. drush sqlc
+      mariadb-client \
       # Git and unzip are required by composer
       git \
       unzip \

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -35,8 +35,8 @@ RUN \
       php${PHP_VERSION}-imagick \
       php${PHP_VERSION}-memcache \
       php${PHP_VERSION}-memcached \
-      # Mysql-client added to support eg. drush sqlc
-      mysql-client \
+      # mariadb-client added to support eg. drush sqlc
+      mariadb-client \
       # Git and unzip are required by composer
       git \
       unzip \

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -35,8 +35,8 @@ RUN \
       php${PHP_VERSION}-imagick \
       php${PHP_VERSION}-memcache \
       php${PHP_VERSION}-memcached \
-      # Mysql-client added to support eg. drush sqlc
-      mysql-client \
+      # mariadb-client added to support eg. drush sqlc
+      mariadb-client \
       # Git and unzip are required by composer
       git \
       unzip \

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -35,8 +35,8 @@ RUN \
       php${PHP_VERSION}-imagick \
       php${PHP_VERSION}-memcache \
       php${PHP_VERSION}-memcached \
-      # Mysql-client added to support eg. drush sqlc
-      mysql-client \
+      # mariadb-client added to support eg. drush sqlc
+      mariadb-client \
       # Git and unzip are required by composer
       git \
       unzip \

--- a/Dockerfile-8.0
+++ b/Dockerfile-8.0
@@ -35,8 +35,8 @@ RUN \
       php${PHP_VERSION}-imagick \
       php${PHP_VERSION}-memcache \
       php${PHP_VERSION}-memcached \
-      # Mysql-client added to support eg. drush sqlc
-      mysql-client \
+      # mariadb-client added to support eg. drush sqlc
+      mariadb-client \
       # Git and unzip are required by composer
       git \
       unzip \


### PR DESCRIPTION
I noticed that `mysqldump` from the mysql-client package is incompatible with newer versions of mariadb server we typically use.
