### PR TITLE
Workaround problem in recent PHP versions

### DIFF
--- a/.github/workflows/scan-dockerfile.yml
+++ b/.github/workflows/scan-dockerfile.yml
@@ -36,6 +36,7 @@ jobs:
         image: "reload/drupal-php7-fpm:${{ matrix.php }}"
         acs-report-enable: true
         fail-build: false
+        severity-cutoff: critical
     - name: Include PHP version in SARIF report
       if: ${{ always() }}
       run: |

--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -54,6 +54,10 @@ RUN \
 # later step runs a bit faster.
 RUN phpdismod xdebug
 
+# Workaround problem in recent PHP versions.
+# @see https://bugs.php.net/81424
+RUN install_clean libpcre2-16-0 libpcre2-8-0 libpcre2-32-0
+
 # Add the blackfire repo and install the php-probe.
 # We also fetch the blackfire-agent to get access to the commandlineuploader.
 RUN \

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -54,6 +54,10 @@ RUN \
 # later step runs a bit faster.
 RUN phpdismod xdebug
 
+# Workaround problem in recent PHP versions.
+# @see https://bugs.php.net/81424
+RUN install_clean libpcre2-16-0 libpcre2-8-0 libpcre2-32-0
+
 # Add the blackfire repo and install the php-probe.
 # We also fetch the blackfire-agent to get access to the commandlineuploader.
 RUN \

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -54,6 +54,10 @@ RUN \
 # later step runs a bit faster.
 RUN phpdismod xdebug
 
+# Workaround problem in recent PHP versions.
+# @see https://bugs.php.net/81424
+RUN install_clean libpcre2-16-0 libpcre2-8-0 libpcre2-32-0
+
 # Add the blackfire repo and install the php-probe.
 # We also fetch the blackfire-agent to get access to the commandlineuploader.
 RUN \

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -53,6 +53,10 @@ RUN \
 # later step runs a bit faster.
 RUN phpdismod xdebug
 
+# Workaround problem in recent PHP versions.
+# @see https://bugs.php.net/81424
+RUN install_clean libpcre2-16-0 libpcre2-8-0 libpcre2-32-0
+
 # Add the blackfire repo and install the php-probe.
 # We also fetch the blackfire-agent to get access to the commandlineuploader.
 RUN \

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -53,6 +53,10 @@ RUN \
 # later step runs a bit faster.
 RUN phpdismod xdebug
 
+# Workaround problem in recent PHP versions.
+# @see https://bugs.php.net/81424
+RUN install_clean libpcre2-16-0 libpcre2-8-0 libpcre2-32-0
+
 # Add the blackfire repo and install the php-probe.
 # We also fetch the blackfire-agent to get access to the commandlineuploader.
 RUN \

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -53,6 +53,10 @@ RUN \
 # later step runs a bit faster.
 RUN phpdismod xdebug
 
+# Workaround problem in recent PHP versions.
+# @see https://bugs.php.net/81424
+RUN install_clean libpcre2-16-0 libpcre2-8-0 libpcre2-32-0
+
 # Add the blackfire repo and install the php-probe.
 # We also fetch the blackfire-agent to get access to the commandlineuploader.
 RUN \

--- a/Dockerfile-8.0
+++ b/Dockerfile-8.0
@@ -53,6 +53,10 @@ RUN \
 # later step runs a bit faster.
 RUN phpdismod xdebug
 
+# Workaround problem in recent PHP versions.
+# @see https://bugs.php.net/81424
+RUN install_clean libpcre2-16-0 libpcre2-8-0 libpcre2-32-0
+
 # Add the blackfire repo and install the php-probe.
 # We also fetch the blackfire-agent to get access to the commandlineuploader.
 RUN \


### PR DESCRIPTION
See https://bugs.php.net/81424

The failing tests are unsecure packages in the Linux distribution the images are built upon. The best we can do is probably to ignore them for now.