### PR TITLE
Update action workflow configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run markdownlint
-      uses: actionshub/markdownlint@2.0.2
+      uses: actionshub/markdownlint@main

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,6 +25,7 @@ jobs:
       uses: hadolint/hadolint-action@v1.7.0
       with:
         dockerfile: Dockerfile-${{ matrix.php }}
+        trusted-registries: docker.io
     - uses: e1himself/goss-installation-action@v1.0.4
     - name: Build image
       run: |


### PR DESCRIPTION
The hadolint action needs to explicitly trust Docker registries now. 

The markdown lint action has moved from tagged versions to main. 