### PR TITLE
Pin composer 2 in older images

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -1,6 +1,6 @@
 # -*- Dockerfile -*-
 FROM composer:1 AS composer-1
-FROM composer:2 AS composer-2
+FROM composer:2.2 AS composer-2
 
 FROM phusion/baseimage:focal-1.2.0
 

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -1,6 +1,6 @@
 # -*- Dockerfile -*-
 FROM composer:1 AS composer-1
-FROM composer:2 AS composer-2
+FROM composer:2.2 AS composer-2
 
 FROM phusion/baseimage:focal-1.2.0
 

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -1,6 +1,6 @@
 # -*- Dockerfile -*-
 FROM composer:1 AS composer-1
-FROM composer:2 AS composer-2
+FROM composer:2.2 AS composer-2
 
 FROM phusion/baseimage:focal-1.2.0
 


### PR DESCRIPTION
Composer 2.3 requires PHP 7.2.5+, so pin the older images to composer
2.2.
