### PR TITLE
Fix up composer installation

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -1,7 +1,4 @@
 # -*- Dockerfile -*-
-FROM composer:1 AS composer-1
-FROM composer:2.2 AS composer-2
-
 FROM phusion/baseimage:focal-1.2.0
 
 ENV PHP_VERSION 5.6
@@ -72,9 +69,9 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Copy Composer in from official images
-COPY --from=composer-2 /usr/bin/composer /usr/bin/composer
-COPY --from=composer-1 /usr/bin/composer /usr/bin/composer-1
+# Copy Composer in from official image
+# hadolint ignore=DL3022
+COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -1,7 +1,4 @@
 # -*- Dockerfile -*-
-FROM composer:1 AS composer-1
-FROM composer:2.2 AS composer-2
-
 FROM phusion/baseimage:focal-1.2.0
 
 ENV PHP_VERSION 7.0
@@ -72,9 +69,9 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Copy Composer in from official images
-COPY --from=composer-2 /usr/bin/composer /usr/bin/composer
-COPY --from=composer-1 /usr/bin/composer /usr/bin/composer-1
+# Copy Composer in from official image
+# hadolint ignore=DL3022
+COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -1,7 +1,4 @@
 # -*- Dockerfile -*-
-FROM composer:1 AS composer-1
-FROM composer:2.2 AS composer-2
-
 FROM phusion/baseimage:focal-1.2.0
 
 ENV PHP_VERSION 7.1
@@ -72,9 +69,9 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Copy Composer in from official images
-COPY --from=composer-2 /usr/bin/composer /usr/bin/composer
-COPY --from=composer-1 /usr/bin/composer /usr/bin/composer-1
+# Copy Composer in from official image
+# hadolint ignore=DL3022
+COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -1,7 +1,4 @@
 # -*- Dockerfile -*-
-FROM composer:1 AS composer-1
-FROM composer:2 AS composer-2
-
 FROM phusion/baseimage:focal-1.2.0
 
 ENV PHP_VERSION 7.2
@@ -71,9 +68,9 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Copy Composer in from official images
-COPY --from=composer-2 /usr/bin/composer /usr/bin/composer
-COPY --from=composer-1 /usr/bin/composer /usr/bin/composer-1
+# Copy Composer in from official image
+# hadolint ignore=DL3022
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -1,7 +1,4 @@
 # -*- Dockerfile -*-
-FROM composer:1 AS composer-1
-FROM composer:2 AS composer-2
-
 FROM phusion/baseimage:focal-1.2.0
 
 ENV PHP_VERSION 7.3
@@ -71,9 +68,9 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Copy Composer in from official images
-COPY --from=composer-2 /usr/bin/composer /usr/bin/composer
-COPY --from=composer-1 /usr/bin/composer /usr/bin/composer-1
+# Copy Composer in from official image
+# hadolint ignore=DL3022
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -1,7 +1,4 @@
 # -*- Dockerfile -*-
-FROM composer:1 AS composer-1
-FROM composer:2 AS composer-2
-
 FROM phusion/baseimage:focal-1.2.0
 
 ENV PHP_VERSION 7.4
@@ -71,9 +68,9 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Copy Composer in from official images
-COPY --from=composer-2 /usr/bin/composer /usr/bin/composer
-COPY --from=composer-1 /usr/bin/composer /usr/bin/composer-1
+# Copy Composer in from official image
+# hadolint ignore=DL3022
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # Add cgr as a replacement for composer global require.
 # This ensures that dependencies used by applications installed via composer do not conflict.

--- a/Dockerfile-8.0
+++ b/Dockerfile-8.0
@@ -1,7 +1,4 @@
 # -*- Dockerfile -*-
-FROM composer:1 AS composer-1
-FROM composer:2 AS composer-2
-
 FROM phusion/baseimage:focal-1.2.0
 
 ENV PHP_VERSION 8.0
@@ -71,9 +68,9 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Copy Composer in from official images
-COPY --from=composer-2 /usr/bin/composer /usr/bin/composer
-COPY --from=composer-1 /usr/bin/composer /usr/bin/composer-1
+# Copy Composer in from official image
+# hadolint ignore=DL3022
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # Let composer global intall in /usr/local/bin.
 RUN composer global config bin-dir /usr/local/bin

--- a/Dockerfile-8.1
+++ b/Dockerfile-8.1
@@ -1,7 +1,4 @@
 # -*- Dockerfile -*-
-FROM composer:1 AS composer-1
-FROM composer:2 AS composer-2
-
 FROM phusion/baseimage:focal-1.2.0
 
 ENV PHP_VERSION 8.1
@@ -75,9 +72,9 @@ RUN \
   touch /var/log/fpm-php.www.log && \
   chown www-data:www-data /var/log/fpm-php.www.log
 
-# Copy Composer in from official images
-COPY --from=composer-2 /usr/bin/composer /usr/bin/composer
-COPY --from=composer-1 /usr/bin/composer /usr/bin/composer-1
+# Copy Composer in from official image
+# hadolint ignore=DL3022
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # Let composer global intall in /usr/local/bin.
 RUN composer global config bin-dir /usr/local/bin

--- a/goss.yaml
+++ b/goss.yaml
@@ -19,8 +19,6 @@ port:
 command:
   composer:
     exit-status: 0
-  composer-1:
-    exit-status: 0
   drush:
     exit-status: 0
   # Test wait-for-it by testing a port we know is available at this point.


### PR DESCRIPTION
Don't use a from image to stop dependabot from trying to upgrade
composer. Older PHPs needs a specific version, and for others latest
is fine.

Remove composer v1.